### PR TITLE
Add ROCm support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ flash-attn==2.6.3
 sentencepiece
 wandb
 einops
-xformers==0.0.27
 optimum==1.16.2
 hf_transfer
 colorama

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,11 @@ def parse_requirements():
                 _install_requires.append(line)
 
     try:
-        xformers_version = [req for req in _install_requires if "xformers" in req][0]
+        # xformers_version = [req for req in _install_requires if "xformers" in req][0]
         if "Darwin" in platform.system():
             # don't install xformers on MacOS
-            _install_requires.pop(_install_requires.index(xformers_version))
+            # _install_requires.pop(_install_requires.index(xformers_version))
+            pass
         else:
             # detect the version of torch already installed
             # and set it so dependencies don't clobber the torch version
@@ -51,14 +52,17 @@ def parse_requirements():
 
             if (major, minor) >= (2, 3):
                 if patch == 0:
-                    _install_requires.pop(_install_requires.index(xformers_version))
-                    _install_requires.append("xformers>=0.0.26.post1")
+                    # _install_requires.pop(_install_requires.index(xformers_version))
+                    # _install_requires.append("xformers>=0.0.26.post1")
+                    pass
             elif (major, minor) >= (2, 2):
-                _install_requires.pop(_install_requires.index(xformers_version))
-                _install_requires.append("xformers>=0.0.25.post1")
+                # _install_requires.pop(_install_requires.index(xformers_version))
+                # _install_requires.append("xformers>=0.0.25.post1")
+                pass
             else:
-                _install_requires.pop(_install_requires.index(xformers_version))
-                _install_requires.append("xformers>=0.0.23.post1")
+                # _install_requires.pop(_install_requires.index(xformers_version))
+                # _install_requires.append("xformers>=0.0.23.post1")
+                pass
 
     except PackageNotFoundError:
         pass

--- a/src/axolotl/monkeypatch/llama_attn_hijack_flash.py
+++ b/src/axolotl/monkeypatch/llama_attn_hijack_flash.py
@@ -22,7 +22,11 @@ from transformers.models.llama.modeling_llama import (
     apply_rotary_pos_emb,
     repeat_kv,
 )
-from xformers.ops import SwiGLU
+# from xformers.ops import SwiGLU
+
+class SwiGLU:
+    def __init__():
+        print("hi")
 
 from axolotl.monkeypatch.utils import get_cu_seqlens_from_pos_ids, set_module_name
 
@@ -45,15 +49,15 @@ LOG = logging.getLogger("axolotl")
 
 
 def is_xformers_swiglu_available() -> bool:
-    from xformers.ops.common import get_xformers_operator
+    # from xformers.ops.common import get_xformers_operator
 
-    try:
-        get_xformers_operator("swiglu_packedw")()
-        return True
-    except RuntimeError as exc:
-        if "No such operator xformers::swiglu_packedw " in str(exc):
-            return False
-        return True
+    # try:
+    #     get_xformers_operator("swiglu_packedw")()
+    #     return True
+    # except RuntimeError as exc:
+    #     if "No such operator xformers::swiglu_packedw " in str(exc):
+    #         return False
+    return False
 
 
 def replace_llama_mlp_with_swiglu(model):


### PR DESCRIPTION
This branch makes `Axolotl` compatible with `ROCm`, following the guidelines from the official `Axolotl documentation`. For more details, see [here](https://github.com/axolotl-ai-cloud/axolotl/blob/7b9f669a3ab18aecb00b17e7f2885aeb458440c8/docs/amd_hpc.qmd).